### PR TITLE
fix: For tests to working directory should be package

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,25 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        meteor: [ '1.8.2', '1.9.3', '1.10.2' ]
+    name: Meteor ${{ matrix.meteor }} sample
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup meteor
+        uses: CanyLink/setup-meteor@v1
+        with:
+          meteor-release: ${{ matrix.meteor }}
+      - run: meteor npm install
+      - run: meteor npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,5 +21,10 @@ jobs:
         uses: CanyLink/setup-meteor@v1
         with:
           meteor-release: ${{ matrix.meteor }}
+
+      - defaults:
+            run:
+              shell: bash
+              working-directory: package
       - run: meteor npm install
       - run: meteor npm test


### PR DESCRIPTION
This action will run tests using 3 latest versions for each of 3 latest minor versions (1.8, 1.9, 1.10) which could good addition to already presented tests with circleci

Requirements for PR from @aldeed 
- [ ] should not be limited to the master branch for PRs, it should run on all
- [ ] it should run non-Meteor tests as a separate job, which is cd package && npm run lintAndTest (or lint and test as two separate jobs)
- [ ] Meteor tests do not run in /package. For Meteor tests job the command should be cd tests/meteor-app && meteor npm install && npm test