### PR TITLE
chore: added testing and autopublish when new tag pushed 

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,51 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        meteor: [ '1.9.3', '1.10.2' ]
+    name: Meteor ${{ matrix.meteor }} sample
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup meteor
+        uses: CanyLink/setup-meteor@v1.0.3
+        with:
+          meteor-release: ${{ matrix.meteor }}
+      - run: meteor npm install
+      - run: meteor npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Setup meteor
-        uses: CanyLink/setup-meteor@v1.0.3
+        uses: CanyLink/setup-meteor@v1
         with:
           meteor-release: ${{ matrix.meteor }}
       - run: meteor npm install


### PR DESCRIPTION
This github action when new tag pushed to the repo will go through tests and after will do auto publish to npm (but don't forget to supply repo with npm auth token in settings -> secrets. You need secret with name npm_token and auth token from npm)